### PR TITLE
Add CLI base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,16 @@ WORKDIR /workspace
 
 RUN make
 
-FROM scratch
+FROM alpine:3.12
 
+RUN addgroup -g 1000 -S keyman \
+  && adduser -h /var/lib/keyman -s /sbin/nologin -G keyman -S -D -u 1000 keyman
 COPY --from=builder /workspace/bin/* /usr/local/bin/
+
+VOLUME [ "/var/lib/keyman" ]
+
+WORKDIR /var/lib/keyman
+USER keyman
+ENV KEYMAN_HOME=/var/lib/keyman
+
 ENTRYPOINT [ "keyman" ]

--- a/cmd/keyman/main.go
+++ b/cmd/keyman/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "fmt"
+import (
+	"keyman/internal/app"
+	"keyman/internal/cmd"
+	"os"
+)
 
 func main() {
-	panic(fmt.Errorf("not implemented"))
+	args := os.Args[1:]
+	code := app.Run(new(cmd.MainCommand), args...)
+	os.Exit(code)
 }

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/app/executor.go
+++ b/internal/app/executor.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"flag"
+	"fmt"
+	"io"
+)
+
+// Executor execute the Command and handles the error.
+type Executor struct {
+	Stderr io.Writer
+}
+
+// Run executes the Command.
+func (e *Executor) Run(cmd Command, args ...string) error {
+	f := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	f.SetOutput(e.Stderr)
+	f.Usage = Usage(cmd, f)
+	cmd.Setup(f)
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	return cmd.Run(f.Args())
+}
+
+// HandleError returns the exit code for err.
+func (e *Executor) HandleError(err error) int {
+	if err == nil {
+		return 0
+	}
+	if err == flag.ErrHelp {
+		return 2
+	}
+
+	fmt.Fprintln(e.Stderr, err)
+	return 1
+}

--- a/internal/app/executor_test.go
+++ b/internal/app/executor_test.go
@@ -1,0 +1,95 @@
+package app_test
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"keyman/internal/app"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type CommandMock struct {
+	mock.Mock
+}
+
+func (m *CommandMock) Name() string {
+	return m.Called().String(0)
+}
+
+func (m *CommandMock) Synopsis() []string {
+	return m.Called().Get(0).([]string)
+}
+
+func (m *CommandMock) Setup(f *flag.FlagSet) {
+	m.Called(f)
+}
+
+func (m *CommandMock) Run(args []string) error {
+	return m.Called(args).Error(0)
+}
+
+type ExecutorTestSuite struct {
+	suite.Suite
+}
+
+func (s *ExecutorTestSuite) TestRun() {
+	cmd := new(CommandMock)
+	cmd.On("Name").Return("test")
+	cmd.On("Setup", mock.Anything)
+	cmd.On("Run", mock.Anything).Return(nil)
+
+	stderr := bytes.NewBuffer([]byte{})
+
+	exec := &app.Executor{Stderr: stderr}
+	err := exec.Run(cmd)
+
+	s.NoError(err)
+	cmd.AssertExpectations(s.T())
+}
+
+func (s *ExecutorTestSuite) TestRunHelp() {
+	cmd := new(CommandMock)
+	cmd.On("Name").Return("test")
+	cmd.On("Synopsis").Return([]string{"test [option]"})
+	cmd.On("Setup", mock.Anything)
+
+	stderr := bytes.NewBuffer([]byte{})
+	exec := &app.Executor{Stderr: stderr}
+
+	err := exec.Run(cmd, "-h")
+
+	s.Equal(flag.ErrHelp, err)
+	s.Contains(stderr.String(), "Usage:")
+	cmd.AssertExpectations(s.T())
+}
+
+func (s *ExecutorTestSuite) TestHandleError() {
+	tests := []struct {
+		name   string
+		err    error
+		want   int
+		stderr []byte
+	}{
+		{name: "nil", stderr: []byte{}},
+		{name: "flag.ErrHelp", err: flag.ErrHelp, want: 2, stderr: []byte{}},
+		{name: "others", err: errors.New("test error"), want: 1, stderr: []byte("test error\n")},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			stderr := bytes.NewBuffer([]byte{})
+			exec := &app.Executor{Stderr: stderr}
+
+			got := exec.HandleError(tt.err)
+
+			s.Equal(tt.want, got)
+			s.Equal(tt.stderr, stderr.Bytes())
+		})
+	}
+}
+
+func TestExecutorTestSuite(t *testing.T) {
+	suite.Run(t, new(ExecutorTestSuite))
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1,0 +1,10 @@
+package app
+
+import "os"
+
+// Run executes the Command and returns the exit code.
+func Run(cmd Command, args ...string) int {
+	exec := &Executor{Stderr: os.Stderr}
+	err := exec.Run(cmd, args...)
+	return exec.HandleError(err)
+}

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -1,0 +1,21 @@
+package app_test
+
+import (
+	"keyman/internal/app"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRun(t *testing.T) {
+	cmd := new(CommandMock)
+	cmd.On("Name").Return("test")
+	cmd.On("Setup", mock.Anything).Return()
+	cmd.On("Run", mock.Anything).Return(nil)
+
+	code := app.Run(cmd)
+
+	assert.Equal(t, 0, code)
+	cmd.AssertExpectations(t)
+}

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -1,0 +1,11 @@
+package app
+
+import "flag"
+
+// Command is the interface of the CLI application.
+type Command interface {
+	Name() string
+	Synopsis() []string
+	Setup(*flag.FlagSet)
+	Run(args []string) error
+}

--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Usage returns the Usage function.
+func Usage(cmd Command, f *flag.FlagSet) func() {
+	return func() {
+		w := f.Output()
+
+		synopsis := cmd.Synopsis()
+		fmt.Fprintf(w, "Usage: %s\n", synopsis[0])
+		for _, s := range synopsis[1:] {
+			fmt.Fprintf(w, "       %s\n", s)
+		}
+
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Options:")
+		fmt.Fprintln(w, "  -h    show this message")
+		f.PrintDefaults()
+	}
+}

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -1,0 +1,48 @@
+package app_test
+
+import (
+	"bytes"
+	"flag"
+	"keyman/internal/app"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsage(t *testing.T) {
+	tests := []struct {
+		name     string
+		synopsis []string
+	}{
+		{
+			name:     "single",
+			synopsis: []string{"test [option]"},
+		},
+		{
+			name: "multiple",
+			synopsis: []string{
+				"test [option]",
+				"test foo",
+				"test bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+
+			cmd := new(CommandMock)
+			cmd.On("Synopsis").Return(tt.synopsis)
+
+			w := bytes.NewBuffer([]byte{})
+			f := flag.NewFlagSet("test", flag.ContinueOnError)
+			f.SetOutput(w)
+			app.Usage(cmd, f)()
+
+			for _, s := range tt.synopsis {
+				assert.Contains(t, w.String(), s)
+			}
+			cmd.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"keyman"
+	"keyman/internal/app"
+	"os"
+)
+
+// MainCommand is the main command.
+type MainCommand struct {
+	Usage   func()
+	Stdout  io.Writer
+	Stderr  io.Writer
+	Version bool
+	Actions []app.Command
+}
+
+// Name returns os.Args[0].
+func (c *MainCommand) Name() string {
+	return os.Args[0]
+}
+
+// Synopsis returns the synopsis of the MainCommand.
+func (c *MainCommand) Synopsis() []string {
+	s := []string{os.Args[0] + " [options]"}
+	for _, act := range c.Actions {
+		s = append(s, act.Synopsis()...)
+	}
+	return s
+}
+
+// Setup sets up MainCommand and flag.FlagSet.
+func (c *MainCommand) Setup(f *flag.FlagSet) {
+	f.BoolVar(&c.Version, "V", false, "show version")
+	c.Usage = f.Usage
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Actions = []app.Command{}
+}
+
+// Run executes the MainCommand.
+func (c *MainCommand) Run(args []string) error {
+	if c.Version {
+		fmt.Fprintf(c.Stdout, "Keyman %s\n", keyman.Version())
+		return nil
+	}
+
+	if len(args) == 0 {
+		c.Usage()
+		return flag.ErrHelp
+	}
+
+	for _, cmd := range c.Actions {
+		if cmd.Name() == args[0] {
+			exec := app.Executor{Stderr: c.Stderr}
+			return exec.Run(cmd, args[1:]...)
+		}
+	}
+	fmt.Fprintf(c.Stderr, "action provided but not defined: %s\n", args[0])
+	return flag.ErrHelp
+}

--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -1,0 +1,176 @@
+package cmd_test
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"keyman/internal/app"
+	"keyman/internal/cmd"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type CommandMock struct {
+	app.Command
+	mock.Mock
+}
+
+func (m *CommandMock) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *CommandMock) Synopsis() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}
+
+func (m *CommandMock) Setup(f *flag.FlagSet) {
+	m.Called(f)
+}
+
+func (m *CommandMock) Run(args []string) error {
+	return m.Called(args).Error(0)
+}
+
+type MainCommandTestSuite struct {
+	suite.Suite
+}
+
+func (s *MainCommandTestSuite) TestName() {
+	c := new(cmd.MainCommand)
+	s.NotEmpty(c.Name())
+}
+
+func (s *MainCommandTestSuite) TestSynopsis() {
+	act := new(CommandMock)
+	act.On("Synopsis").Return([]string{"foo", "bar"})
+
+	c := new(cmd.MainCommand)
+	c.Actions = append(c.Actions, act)
+	s.Len(c.Synopsis(), 3)
+
+	act.AssertExpectations(s.T())
+}
+
+func (s *MainCommandTestSuite) TestSetup() {
+	f := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	c := new(cmd.MainCommand)
+	c.Setup(f)
+
+	s.Equal(os.Stdout, c.Stdout)
+	s.Equal(os.Stderr, c.Stderr)
+	s.Empty(c.Actions)
+}
+
+func (s *MainCommandTestSuite) TestRun() {
+	tests := []struct {
+		name   string
+		args   []string
+		stdout []byte
+		stderr []byte
+	}{
+		{
+			name:   "keyman test",
+			args:   []string{"test"},
+			stdout: []byte{},
+			stderr: []byte{},
+		},
+		{
+			name:   "keyman -V",
+			args:   []string{"-V"},
+			stdout: []byte("Keyman 0.0.0\n"),
+			stderr: []byte{},
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			f := flag.NewFlagSet("test", flag.ContinueOnError)
+			stdout := bytes.NewBuffer([]byte{})
+			stderr := bytes.NewBuffer([]byte{})
+
+			act := new(CommandMock)
+			act.On("Name").Return("test")
+			act.On("Setup", mock.Anything)
+			act.On("Run", mock.Anything).Return(nil)
+
+			c := new(cmd.MainCommand)
+			c.Setup(f)
+			c.Stdout = stdout
+			c.Stderr = stderr
+			c.Actions = []app.Command{act}
+
+			if !s.NoError(f.Parse(tt.args)) {
+				return
+			}
+
+			err := c.Run(f.Args())
+			if !s.NoError(err) {
+				return
+			}
+			s.Equal(tt.stdout, stdout.Bytes())
+			s.Equal(tt.stderr, stderr.Bytes())
+		})
+	}
+}
+
+func (s *MainCommandTestSuite) TestRunErr() {
+	tests := []struct {
+		name   string
+		args   []string
+		stdout []byte
+		stderr []byte
+	}{
+		{
+			name:   "keyman",
+			args:   []string{},
+			stdout: []byte{},
+			stderr: []byte{},
+		},
+		{
+			name:   "keyman test",
+			args:   []string{"test"},
+			stdout: []byte{},
+			stderr: []byte{},
+		},
+		{
+			name:   "keyman error",
+			args:   []string{"error"},
+			stdout: []byte{},
+			stderr: []byte{},
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			f := flag.NewFlagSet("test", flag.ContinueOnError)
+			stdout := bytes.NewBuffer([]byte{})
+			stderr := bytes.NewBuffer([]byte{})
+
+			act := new(CommandMock)
+			act.On("Name").Return("test")
+			act.On("Setup", mock.Anything)
+			act.On("Run", mock.Anything).Return(errors.New("test error"))
+
+			c := new(cmd.MainCommand)
+			c.Setup(f)
+			c.Stdout = stdout
+			c.Stderr = stderr
+			c.Actions = []app.Command{act}
+
+			if !s.NoError(f.Parse(tt.args)) {
+				return
+			}
+
+			err := c.Run(f.Args())
+			s.Error(err)
+		})
+	}
+}
+
+func TestMainCommandTestSuite(t *testing.T) {
+	suite.Run(t, new(MainCommandTestSuite))
+}


### PR DESCRIPTION
This adds a CLI template.

Like `MainCommand`, commands are created by implementing the `Command` interface.
